### PR TITLE
fix: add per-call timeout to _viber_call, working ack for slow commands

### DIFF
--- a/scripts/bridge.py
+++ b/scripts/bridge.py
@@ -226,10 +226,18 @@ class Bridge:
             except ViberError as e:
                 await self.matrix.send_notice(room_id, f"⚠️ Viber error: {e}")
 
-    async def _viber_call(self, fn, *fargs, **fkwargs):
-        """Run a (synchronous) Viber operation under the lock, off the event loop."""
+    async def _viber_call(self, fn, *fargs, timeout: float = 15.0, **fkwargs):
+        """Run a (synchronous) Viber operation under the lock, off the event loop.
+
+        The operation is wrapped with a timeout so a hung UIA call surfaces as
+        an error rather than blocking the lock indefinitely. Raises
+        asyncio.TimeoutError if the operation exceeds *timeout* seconds.
+        """
         async with self._viber_lock:
-            return await asyncio.to_thread(fn, *fargs, **fkwargs)
+            return await asyncio.wait_for(
+                asyncio.to_thread(fn, *fargs, **fkwargs),
+                timeout=timeout,
+            )
 
     # ---- Control-room commands ---------------------------------------
     async def _on_control(self, cmd: str, args: list[str], sender: str) -> str | None:
@@ -278,6 +286,10 @@ class Bridge:
             existing = await self.state.get_room_for_viber(vname)
             if existing:
                 return f"already paired: {vname!r} → {existing}"
+            await self.matrix.send_text(
+                self.cfg["matrix"]["control_room_id"],
+                f"⏳ Searching Viber for {vname!r}...",
+            )
             opened = await self._viber_call(self.viber.open_conversation_by_search, vname)
             if not opened:
                 return f"could not find a Viber chat matching {vname!r}"
@@ -315,6 +327,10 @@ class Bridge:
             if not args:
                 return "usage: !test <viber contact or group name>"
             vname = " ".join(args)
+            await self.matrix.send_text(
+                self.cfg["matrix"]["control_room_id"],
+                f"⏳ Opening Viber chat {vname!r}...",
+            )
             try:
                 opened = await self._viber_call(self.viber.open_conversation_by_search, vname)
                 if not opened:


### PR DESCRIPTION
Fixes #8

## Changes (remaining items from issue)
- **Per-call timeout**: `_viber_call` now wraps `asyncio.to_thread` in `asyncio.wait_for(timeout=15.0)`. A hung UIA click surfaces as `asyncio.TimeoutError` reported to the control room instead of blocking the `_viber_lock` indefinitely.
- **Working ack**: `!addchat` and `!test` now send an immediate \`⏳ Searching Viber for ...\` message before starting the UIA operation, so the user sees the bridge is alive.

## Testing
- Manual unit test verified: Python syntax and import OK